### PR TITLE
Setuptools fixes

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,7 @@ build:
 requirements:
   build:
     - python
+    - setuptools
 
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   md5: 2f8352acfedf83f701a564583db5e14d
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record=record.txt
   entry_points:
     - kernprof=kernprof:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,8 @@ source:
 build:
   number: 0
   script: python setup.py install --single-version-externally-managed --record=record.txt
+  entry_points:
+    - kernprof=kernprof:main
 
 requirements:
   build:
@@ -28,6 +30,7 @@ test:
     - line_profiler
 
   commands:
+    - kernprof --help
     - python -m kernprof --help
     - python -m line_profiler --help
 


### PR DESCRIPTION
- Explicitly add `setuptools` as a build requirement.
- List all entry points explicitly to avoid `setuptools` entrypoints.
- Test all entry points.
- Bump the build number to `1`.
